### PR TITLE
bugfix - config changes to make tests run

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Vector DB   LLM Manager
 
 ## Tech stack
 
-- **Python 3.11+**
+- **Python 3.11+, <3.14.1**
 - **pytest** for testing
 - **ruff** for linting and formatting
 - **LangChain** + **LangGraph** for RAG pipeline and LLM integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "garys-economics-chatbot"
 version = "0.1.0"
 description = "A RAG chatbot that answers economics questions by referencing Gary's Economics YouTube videos."
 license = "GPL-3.0-or-later"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14.1"
 dependencies = [
     "chromadb",
     "discord.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ target-version = "py311"
 select = ["E", "F", "W", "I"]
 
 [tool.pytest.ini_options]
+pythonpath = ["./src"]
 testpaths = ["tests"]
 markers = [
     "langfuse: tests that require a running Langfuse server and credentials",


### PR DESCRIPTION
### What has been changed?

1. pyproject.toml has been updated to include the Python upper version limit of <3.14.1 to prevent the incompatible version from being used. README.md has been updated to reflect the change.
1. `pythonpath` has been added in test config to include `./src` 

### What was the reason for the change?
Tests were failing due to two project config issues.

1. The project was missing the python upper version restriction. Tests were failing when run with Python version 3.14.1+ due to incompatibility with Pydantic V1. 
    ```
    ================================================================================= short test summary info ==================================================================================
    ERROR tests/test_discord_bot.py - pydantic.v1.errors.ConfigError: unable to infer type for attribute "description"
    ERROR tests/test_langfuse.py - pydantic.v1.errors.ConfigError: unable to infer type for attribute "description"
    ERROR tests/test_llm_manager.py - pydantic.v1.errors.ConfigError: unable to infer type for attribute "description"
    ERROR tests/test_rag_manager.py - pydantic.v1.errors.ConfigError: unable to infer type for attribute "description"
    ERROR tests/test_telegram_bot.py - pydantic.v1.errors.ConfigError: unable to infer type for attribute "description"
    ```
1. `src` was not included in the pythonpath for pytest. Tests were failing with
    ``` 
    ImportError while loading conftest '[snip]/chatbot/tests/conftest.py'.
    tests/conftest.py:3: in <module>
        from config import settings
    E   ModuleNotFoundError: No module named 'config'
    ```

### How has been test?
Tested locally with python 3.13.13 and 3.14.[0-4] 
