### PR TITLE
bugfix - fix the broken tests by using langchain-community v. 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "langchain",
     "langfuse>=3,<4",
     "langchain-chroma",
-    "langchain-community",
+    "langchain-community<=0.4.1",
     "langchain-ollama",
     "langchain-text-splitters",
     "langgraph",


### PR DESCRIPTION
### What has been changed?

The version of langchain-community has been fixed set to <= 0.4.1

```    
"langchain-community<=0.4.1",
```

### What was the reason for the change?

Versions above 0.4.1 do not have ChatOpenAI

```
    from langchain_community.chat_models import ChatOpenAI
E   ImportError: cannot import name 'ChatOpenAI' from 'langchain_community.chat_models' (/Users/naree/.pyenv/versions/3.13.13/lib/python3.13/site-packages/langchain_community/chat_models/_
_init__.py)
```

### How has been test?

Tested locally using `pytest`