### PR TITLE
Replace retired Ollama Cloud model with gemma4:latest

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
                 "type": "ollama",
                 "url": self.ollama_cloud_url,
                 "api_key": self.ollama_cloud_api_key,
-                "chat_model": "qwen3-next:80b",
+                "chat_model": "gemma4:latest",
             },
             "openrouter": {
                 # This is the client type

--- a/tests/test_rag_manager.py
+++ b/tests/test_rag_manager.py
@@ -38,7 +38,7 @@ async def test_rag_query_end_to_end(use_ollama_for_testing):
 
 @pytest.mark.asyncio
 async def test_rag_query_ollama_cloud():
-    """Verify qwen3-next:80b returns a non-empty answer."""
+    """Verify ollama_cloud chat model returns a non-empty answer."""
     settings.chat_provider_priority = ["ollama_cloud"]
     question = "What is wealth?"
     response = await RAG_query(question, user_id="test")


### PR DESCRIPTION
## Summary

- `qwen3-next:80b` was retired on Ollama Cloud (2026-06-16), breaking `test_chat_ollama_cloud` and leaving production without a working chat model on that provider.
- Tested `qwen3.6:latest` (404 — not found) and `gemma4:latest` (passing). Updated `config.py` to use `gemma4:latest`.
- Removed the hardcoded model name from the `test_rag_query_ollama_cloud` docstring so it doesn't go stale again.

## Test plan

- [x] `test_chat_ollama_cloud` passes with `gemma4:latest`
- [x] `test_rag_query_ollama_cloud` passes
- [x] Full test suite: 57/57 passed